### PR TITLE
Adds type annotations so that reflection warnings are prevented.

### DIFF
--- a/src/lambdaisland/cucumber/jvm/types.clj
+++ b/src/lambdaisland/cucumber/jvm/types.clj
@@ -9,23 +9,23 @@
 (defn file-resource ^Resource [^File root ^File file]
   (reify
     Resource
-    (getPath ^String [this]
+    (getPath ^String [_]
       (.getPath file))
-    (getInputStream ^InputStream [this]
+    (getInputStream ^InputStream [_]
       (FileInputStream. file))
 
     Object
-    (toString [this]
+    (toString [_]
       (str "<file-resource: @root=" root ", @file=" file ">"))))
 
 (defn file-resource-seq ^Iterator [root suffix]
   (->> (io/file root)
        file-seq
-       (filter (fn [f]
+       (filter (fn [^File f]
                  (and (.isFile f) (str/ends-with? (str f) suffix))))
        (map #(file-resource root %))))
 
 (defn file-resource-loader ^ResourceLoader []
   (reify ResourceLoader
-    (^Iterable resources [this ^String path ^String suffix]
+    (^Iterable resources [_ ^String path ^String suffix]
      (file-resource-seq path suffix))))

--- a/src/lambdaisland/cucumber/output.clj
+++ b/src/lambdaisland/cucumber/output.clj
@@ -33,7 +33,7 @@
 (defmethod print-markdown :gherkin/document [{:keys [feature]}]
   (print-markdown feature))
 
-(defmethod print-markdown :gherkin/feature [{:keys [keyword name description children]}]
+(defmethod print-markdown :gherkin/feature [{:keys [name description children]}]
   (println "#" name)
   (println)
   (when (seq description)
@@ -45,8 +45,8 @@
   (println "##" (str keyword ":") name)
   (println)
   (run! print-markdown steps)
-  (println)
-  )
+  (println))
+
 
 (defmethod print-markdown :gherkin/scenario [{:keys [name steps]}]
   (println "##" name)
@@ -85,7 +85,7 @@
                  io/file
                  file-seq
                  (map str)
-                 (filter #(.endsWith % ".feature")))]
+                 (filter #(str/ends-with? % ".feature")))]
     (with-open [out (-> f
                         (str/replace "test/features" "doc")
                         (str/replace ".feature" ".md")
@@ -95,18 +95,18 @@
         (->> f
              jvm/parse
              gherkin/gherkin->edn
-             print-markdown)))
-    )
+             print-markdown))))
+
 
   (->> "resources/lambdaisland/gherkin/test_feature.feature"
        jvm/parse
-       gherkin/gherkin->edn
-       )
+       gherkin/gherkin->edn)
+
 
   (spit "resources/lambdaisland/gherkin/test_feature.md"
         (with-out-str
           (->> "resources/lambdaisland/gherkin/test_feature.feature"
                jvm/parse
                gherkin/gherkin->edn
-               print-markdown)))
-  )
+               print-markdown))))
+

--- a/test/features/step_definitions/steps.clj
+++ b/test/features/step_definitions/steps.clj
@@ -23,5 +23,5 @@
 
 (Given "a {color} ball" [state color]
   (prn (.hex color))
-  state
-  )
+  state)
+

--- a/test/unit/lambdaisland/cucumber/jvm_test.clj
+++ b/test/unit/lambdaisland/cucumber/jvm_test.clj
@@ -15,10 +15,10 @@
 
 (deftest camel->kepab-test
   (is (= "foo-bar-baz"
-         (jvm/camel->kebap "FooBarBaz")))
+         (jvm/camel->kebab "FooBarBaz")))
 
   (is (= "foo-bar"
-         (jvm/camel->kebap "fooBar"))))
+         (jvm/camel->kebab "fooBar"))))
 
 (deftest clojure-snippet-test
   (testing "template"
@@ -297,5 +297,5 @@
 
 (comment
   (require 'kaocha.repl)
-  (kaocha.repl/run 'lambdaisland.cucumber.jvm-test)
-  )
+  (kaocha.repl/run 'lambdaisland.cucumber.jvm-test))
+


### PR DESCRIPTION
See issue https://github.com/lambdaisland/kaocha-cucumber/issues/3

When code under test contains `(set! *warn-on-reflection* true)` the output contains reflection warnings from the kaocha-cucumber namespace. This PR adds type annotations so these warnings are prevented.

Feedback is greatly appreciated.