### PR TITLE
Fix getting started documentation of where to put the test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ in the pattern.
 
 Inside the step definitions you use `clojure.test` style assertions.
 
+Here's the complete file structure of this example:
+
+```
+.
+├── bin
+│   └── kaocha
+├── deps.edn
+├── test
+│   ├── features
+│   │   └── coffeeshop.feature
+│   └── step_definitions
+│       └── coffeeshop_steps.clj
+└── tests.edn
+```
+
+
 ## Parameter Types
 
 Data tables will be converted to a vector of vectors, other types will be passed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can implement missing steps with the snippets below:
 1 tests, 0 assertions, 1 pending, 0 failures.
 ```
 
-Create a file `test/feature_steps/coffeeshop_steps.clj`, copy the sample code
+Create a file `test/step_definitions/coffeeshop_steps.clj`, copy the sample code
 snippets over, and add a namespace declaration, pulling in
 `lambdaisland.cucumber.dsl` and `clojure.test`.
 


### PR DESCRIPTION
The documentation creates the test steps file in a wrong folder. The commits update the documentation. Plus it shows the complete directory structure of the getting-started example using `tree` command. 