### PR TITLE
Make README consistent with other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ You can find an overview of our projects at [lambdaisland/open-source](https://g
 <!-- contributing -->
 ## Contributing
 
-Everyone has a right to submit patches to glogi, and thus become a contributor.
+Everyone has a right to submit patches to kaocha-cucumber, and thus become a contributor.
 
 Contributors MUST
 

--- a/README.md
+++ b/README.md
@@ -226,10 +226,62 @@ If you have a code base of significant size based on these legacy projects then
 please open a ticket, we might be able to create a separate legacy DSL namespace
 that's compatible with old tests.
 
-<!-- license-epl -->
+<!-- opencollective -->
+## Lambda Island Open Source
+
+<img align="left" src="https://github.com/lambdaisland/open-source/raw/master/artwork/lighthouse_readme.png">
+
+&nbsp;
+
+kaocha-cucumber is part of a growing collection of quality Clojure libraries created and maintained
+by the fine folks at [Gaiwan](https://gaiwan.co).
+
+Pay it forward by [becoming a backer on our Open Collective](http://opencollective.com/lambda-island),
+so that we may continue to enjoy a thriving Clojure ecosystem.
+
+You can find an overview of our projects at [lambdaisland/open-source](https://github.com/lambdaisland/open-source).
+
+&nbsp;
+
+&nbsp;
+<!-- /opencollective -->
+
+<!-- contributing -->
+## Contributing
+
+Everyone has a right to submit patches to glogi, and thus become a contributor.
+
+Contributors MUST
+
+- adhere to the [LambdaIsland Clojure Style Guide](https://nextjournal.com/lambdaisland/clojure-style-guide)
+- write patches that solve a problem. Start by stating the problem, then supply a minimal solution. `*`
+- agree to license their contributions as MPL 2.0.
+- not break the contract with downstream consumers. `**`
+- not break the tests.
+
+Contributors SHOULD
+
+- update the CHANGELOG and README.
+- add tests for new functionality.
+
+If you submit a pull request that adheres to these rules, then it will almost
+certainly be merged immediately. However some things may require more
+consideration. If you add new dependencies, or significantly increase the API
+surface, then we need to decide if these changes are in line with the project's
+goals. In this case you can start by [writing a pitch](https://nextjournal.com/lambdaisland/pitch-template),
+and collecting feedback on it.
+
+`*` This goes for features too, a feature needs to solve a problem. State the problem it solves, then supply a minimal solution.
+
+`**` As long as this project has not seen a public release (i.e. is not on Clojars)
+we may still consider making breaking changes, if there is consensus that the
+changes are justified.
+<!-- /contributing -->
+
+<!-- license -->
 ## License
-&nbsp;
-Copyright &copy; 2018-2019 Arne Brasseur
-&nbsp;
-Available under the terms of the Eclipse Public License 1.0, see LICENSE.txt
-<!-- /license-epl -->
+
+Copyright &copy; 2019-2021 Arne Brasseur and Contributors
+
+Licensed under the term of the Eclipse Public License 1.0, see LICENSE.txt.
+<!-- /license -->


### PR DESCRIPTION
Pull in our usual footer for Lambda Island projects.