### PR TITLE
Adopt our new matrix-based CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.2
-  clojure: lambdaisland/clojure@0.0.6
+  kaocha: lambdaisland/kaocha@0.0.3
+  clojure: lambdaisland/clojure@0.0.8
 
 commands:
   checkout_and_run:
@@ -18,48 +18,24 @@ commands:
                 args: "--reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
       - kaocha/upload_codecov
-
 jobs:
-  java-16-clojure-1_10:
-    executor: clojure/openjdk16
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
+  test:
+    parameters:
+      os:
+        type: executor
+      clojure_version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout_and_run:
+          clojure_version: << parameters.clojure_version >>
 
-  java-16-clojure-1_9:
-    executor: clojure/openjdk16
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-    
-  java-11-clojure-1_10:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-
-  java-11-clojure-1_9:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-
-  java-9-clojure-1_10:
-    executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-
-  java-9-clojure-1_9:
-    executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-
-  java-8-clojure-1_10:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-
-  java-8-clojure-1_9:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
 
 workflows:
   kaocha_test:
     jobs:
-      - java-16-clojure-1_10
-      - java-16-clojure-1_9
-      - java-11-clojure-1_10
-      - java-11-clojure-1_9
-      - java-9-clojure-1_10
-      - java-9-clojure-1_9
-      - java-8-clojure-1_10
-      - java-8-clojure-1_9
+      - test:
+          matrix:
+            parameters:
+              os: [clojure/openjdk19, clojure/openjdk17, clojure/openjdk16, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.10.3", "1.11.1"]


### PR DESCRIPTION
This PR:

- Updates our config to use the latest versions of Clojure and JVM
- Switches over to the matrix-based configuration
